### PR TITLE
fix: provide files directly to `TaxDb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,39 +2,44 @@
 
 ## Next Release
 
+### Fixed
+
+-   Fixed how the `taxopy.TaxDb` is loaded. It was previously deleting local files and
+    downloading a new copy from NCBI instead (#67).
+
 ## 0.2.1 (2023-03-01)
 
 ### Fixed
 
-* Handled metaphlan profiles with unclassified taxa in the lineage (#61).
+-   Handled metaphlan profiles with unclassified taxa in the lineage (#61).
 
 ## 0.2.0 (2023-02-23)
 
 ### Added
 
-* Created command line options to expand the standard profile with name, rank,
-  and/or lineage taxonomic information (#60).
+-   Created command line options to expand the standard profile with name, rank,
+    and/or lineage taxonomic information (#60).
 
 ### Fixed
 
-* Made the Krakenuniq reader more accepting (#57).
-* Documented _which_ columns are used in final standardised output profiles.
+-   Made the Krakenuniq reader more accepting (#57).
+-   Documented _which_ columns are used in final standardised output profiles.
 
 ## 0.1.1 (2023-01-28)
 
 ### Fixed
 
-* Documentation on where the taxpasta-supported Kaiju output comes from (i.e.,
-  kaiju2table rather than Kaiju itself) (#54).
+-   Documentation on where the taxpasta-supported Kaiju output comes from (i.e.,
+    kaiju2table rather than Kaiju itself) (#54).
 
 ### Fixed
 
-* Corrected the assumption that the first two entries in a kraken2 profile are
-  always unclassified and root node percentage of abundances. This is not the
-  case for profiles where 100% of reads are assigned to taxa. Kraken2 profile
-  validation now looks for the `'U'` and `'R'` taxonomy levels explicitly and
-  checks their sum.
+-   Corrected the assumption that the first two entries in a kraken2 profile are
+    always unclassified and root node percentage of abundances. This is not the
+    case for profiles where 100% of reads are assigned to taxa. Kraken2 profile
+    validation now looks for the `'U'` and `'R'` taxonomy levels explicitly and
+    checks their sum.
 
 ## 0.1.0 (2023-01-19)
 
-* First release
+-   First release

--- a/src/taxpasta/infrastructure/domain/service/taxopy_taxonomy_service.py
+++ b/src/taxpasta/infrastructure/domain/service/taxopy_taxonomy_service.py
@@ -49,7 +49,15 @@ class TaxopyTaxonomyService(TaxonomyService):
     @classmethod
     def from_taxdump(cls, source: Path) -> TaxopyTaxonomyService:
         """Create a service instance from a directory path containing taxdump info."""
-        return cls(tax_db=taxopy.TaxDb(taxdb_dir=str(source)))
+        merged = source / "merged.dmp"
+        return cls(
+            tax_db=taxopy.TaxDb(
+                names_dmp=str(source / "names.dmp"),
+                nodes_dmp=str(source / "nodes.dmp"),
+                merged_dmp=str(merged) if merged.is_file() else None,
+                keep_files=True,
+            )
+        )
 
     def get_taxon_name(self, taxonomy_id: int) -> Optional[str]:
         """Return the name of a given taxonomy identifier."""


### PR DESCRIPTION
Providing only a directory, prompts taxopy to delete its contents and download fresh dump files from NCBI. This is not the intended behavior. We want to use local files and keep them.
