### PR TITLE
Render without rich

### DIFF
--- a/docs/how-tos/bash_snippets.md
+++ b/docs/how-tos/bash_snippets.md
@@ -30,7 +30,7 @@ tar -C taxdump -xzf taxdump.tar.gz
 
       0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 
-    100    49  100    49    0     0     33      0  0:00:01  0:00:01 --:--:--    33
+    100    49  100    49    0     0     38      0  0:00:01  0:00:01 --:--:--    38
 
       % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
 
@@ -40,19 +40,19 @@ tar -C taxdump -xzf taxdump.tar.gz
 
       0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 
-      0 57.8M    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
+      0 57.8M    0 17376    0     0  13692      0  1:13:49  0:00:01  1:13:48 13681
 
-     14 57.8M   14 8825k    0     0  4125k      0  0:00:14  0:00:02  0:00:12 4123k
+      8 57.8M    8 4812k    0     0  2169k      0  0:00:27  0:00:02  0:00:25 2168k
 
-     40 57.8M   40 23.3M    0     0  7738k      0  0:00:07  0:00:03  0:00:04 7736k
+     25 57.8M   25 14.8M    0     0  4718k      0  0:00:12  0:00:03  0:00:09 4718k
 
-     56 57.8M   56 32.7M    0     0  8153k      0  0:00:07  0:00:04  0:00:03 8151k
+     42 57.8M   42 24.8M    0     0  6024k      0  0:00:09  0:00:04  0:00:05 6022k
 
-     74 57.8M   74 43.1M    0     0  8663k      0  0:00:06  0:00:05  0:00:01 8998k
+     62 57.8M   62 36.3M    0     0  7159k      0  0:00:08  0:00:05  0:00:03 7447k
 
-     94 57.8M   94 54.5M    0     0  9157k      0  0:00:06  0:00:06 --:--:-- 11.0M
+     85 57.8M   85 49.2M    0     0  8093k      0  0:00:07  0:00:06  0:00:01  9.9M
 
-    100 57.8M  100 57.8M    0     0  9264k      0  0:00:06  0:00:06 --:--:-- 11.5M
+    100 57.8M  100 57.8M    0     0  8566k      0  0:00:06  0:00:06 --:--:-- 11.3M
 
     taxdump.tar.gz: OK
 
@@ -63,17 +63,9 @@ tar -C taxdump -xzf taxdump.tar.gz
 taxpasta merge -p motus -o dbMOTUs_motus_with_names.tsv --taxonomy taxdump --add-name 2612_pe-ERR5766176-db_mOTU.out 2612_se-ERR5766180-db_mOTU.out
 ```
 
-    [13:53:47] WARNING  The merged profiles        d=594523;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/application/sample_merging_application.py\sample_merging_application.py;;\:d=133637;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/application/sample_merging_application.py#116\116;;\
+    [WARNING] The merged profiles contained different taxa. Additional zeroes were introduced for missing taxa.
 
-                        contained different taxa.
-
-                        Additional zeroes were
-
-                        introduced for missing
-
-                        taxa.
-
-               INFO     Write result to 'dbMOTUs_motus_with_names.tsv'. d=221795;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/infrastructure/cli/merge.py\merge.py;;\:d=554515;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/infrastructure/cli/merge.py#448\448;;\
+    [INFO] Write result to 'dbMOTUs_motus_with_names.tsv'.
 
 <!-- --8<-- [end:merge-names] -->
 <!-- --8<-- [start:merge-names-head] -->
@@ -124,19 +116,11 @@ paste motus_names.txt motus_paths.txt >> motus_samplesheet.tsv
 taxpasta merge -p motus -o dbMOTUs_motus_cleannames.tsv -s motus_samplesheet.tsv
 ```
 
-    [13:53:49] INFO     Read sample sheet from 'motus_samplesheet.tsv'. d=301038;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/infrastructure/cli/merge.py\merge.py;;\:d=775761;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/infrastructure/cli/merge.py#393\393;;\
+    [INFO] Read sample sheet from 'motus_samplesheet.tsv'.
 
-               WARNING  The merged profiles        d=737336;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/application/sample_merging_application.py\sample_merging_application.py;;\:d=7963;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/application/sample_merging_application.py#116\116;;\
+    [WARNING] The merged profiles contained different taxa. Additional zeroes were introduced for missing taxa.
 
-                        contained different taxa.
-
-                        Additional zeroes were
-
-                        introduced for missing
-
-                        taxa.
-
-               INFO     Write result to 'dbMOTUs_motus_cleannames.tsv'. d=913213;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/infrastructure/cli/merge.py\merge.py;;\:d=177024;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/infrastructure/cli/merge.py#448\448;;\
+    [INFO] Write result to 'dbMOTUs_motus_cleannames.tsv'.
 
 <!-- --8<-- [end:merge-samplesheet] -->
 <!-- --8<-- [start:merge-samplesheet-head] -->

--- a/docs/quick_reference/merge_help.txt
+++ b/docs/quick_reference/merge_help.txt
@@ -1,117 +1,65 @@
-                                                                                              
- Usage: taxpasta merge [OPTIONS] [PROFILE1 PROFILE2 [...]]                                    
-                                                                                              
- Standardise and merge two or more taxonomic profiles into a single table.                    
-                                                                                              
-╭─ Arguments ────────────────────────────────────────────────────────────────────────────────╮
-│   profiles      [PROFILE1 PROFILE2 [...]]  Two or more files containing taxonomic          │
-│                                            profiles. Required unless there is a sample     │
-│                                            sheet. Filenames will be parsed as sample       │
-│                                            names.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ──────────────────────────────────────────────────────────────────────────────────╮
-│ *  --profiler               -p            [bracken|centrifuge|dia  The taxonomic profiler  │
-│                                           mond|kaiju|kraken2|krak  used. All provided      │
-│                                           enuniq|megan6|metaphlan  profiles must come from │
-│                                           |motus]                  the same tool!          │
-│                                                                    [required]              │
-│    --samplesheet            -s            FILE                     A table with a header   │
-│                                                                    and two columns: the    │
-│                                                                    first column named      │
-│                                                                    'sample' which can be   │
-│                                                                    any string and the      │
-│                                                                    second column named     │
-│                                                                    'profile' which must be │
-│                                                                    a file path to an       │
-│                                                                    actual taxonomic        │
-│                                                                    abundance profile. If   │
-│                                                                    this option is          │
-│                                                                    provided, any arguments │
-│                                                                    are ignored.            │
-│                                                                    [default: None]         │
-│    --samplesheet-format                   [TSV|CSV|ODS|XLSX|arrow  The file format of the  │
-│                                           |parquet]                sample sheet. Depending │
-│                                                                    on the choice,          │
-│                                                                    additional package      │
-│                                                                    dependencies may apply. │
-│                                                                    Will be parsed from the │
-│                                                                    sample sheet file name  │
-│                                                                    but can be set          │
-│                                                                    explicitly.             │
-│                                                                    [default: None]         │
-│ *  --output                 -o            PATH                     The desired output      │
-│                                                                    file. By default, the   │
-│                                                                    file extension will be  │
-│                                                                    used to determine the   │
-│                                                                    output format.          │
-│                                                                    [required]              │
-│    --output-format                        [TSV|CSV|ODS|XLSX|arrow  The desired output      │
-│                                           |parquet|BIOM]           format. Depending on    │
-│                                                                    the choice, additional  │
-│                                                                    package dependencies    │
-│                                                                    may apply. Will be      │
-│                                                                    parsed from the output  │
-│                                                                    file name but can be    │
-│                                                                    set explicitly.         │
-│                                                                    [default: None]         │
-│    --wide                       --long                             Output merged abundance │
-│                                                                    data in either wide or  │
-│                                                                    (tidy) long format.     │
-│                                                                    Ignored when the        │
-│                                                                    desired output format   │
-│                                                                    is BIOM.                │
-│                                                                    [default: wide]         │
-│    --summarise-at,--summa…                TEXT                     Summarise abundance     │
-│                                                                    profiles at higher      │
-│                                                                    taxonomic rank. The     │
-│                                                                    provided option must    │
-│                                                                    match a rank in the     │
-│                                                                    taxonomy exactly. This  │
-│                                                                    is akin to the clade    │
-│                                                                    assigned reads provided │
-│                                                                    by, for example,        │
-│                                                                    kraken2, where the      │
-│                                                                    abundances of a whole   │
-│                                                                    taxonomic branch are    │
-│                                                                    assigned to a taxon at  │
-│                                                                    the desired rank.       │
-│                                                                    Please note that        │
-│                                                                    abundances above the    │
-│                                                                    selected rank are       │
-│                                                                    simply ignored. No      │
-│                                                                    attempt is made to      │
-│                                                                    redistribute those down │
-│                                                                    to the desired rank.    │
-│                                                                    Some tools, like        │
-│                                                                    Bracken, were designed  │
-│                                                                    for this purpose but it │
-│                                                                    doesn't seem like a     │
-│                                                                    problem we can          │
-│                                                                    generally solve here.   │
-│                                                                    [default: None]         │
-│    --taxonomy                             PATH                     The path to a directory │
-│                                                                    containing taxdump      │
-│                                                                    files. At least         │
-│                                                                    nodes.dmp and names.dmp │
-│                                                                    are required. A         │
-│                                                                    merged.dmp file is      │
-│                                                                    optional.               │
-│                                                                    [default: None]         │
-│    --add-name                                                      Add the taxon name to   │
-│                                                                    the output.             │
-│    --add-rank                                                      Add the taxon rank to   │
-│                                                                    the output.             │
-│    --add-lineage                                                   Add the taxon's entire  │
-│                                                                    lineage to the output.  │
-│                                                                    These are taxon names   │
-│                                                                    separated by            │
-│                                                                    semi-colons.            │
-│    --add-id-lineage                                                Add the taxon's entire  │
-│                                                                    lineage to the output.  │
-│                                                                    These are taxon         │
-│                                                                    identifiers separated   │
-│                                                                    by semi-colons.         │
-│    --help                   -h                                     Show this message and   │
-│                                                                    exit.                   │
-╰────────────────────────────────────────────────────────────────────────────────────────────╯
+Usage: taxpasta merge [OPTIONS] [PROFILE1 PROFILE2 [...]]
 
+  Standardise and merge two or more taxonomic profiles.
+
+Arguments:
+  [PROFILE1 PROFILE2 [...]]  Two or more files containing taxonomic profiles.
+                             Required unless there is a sample sheet.
+                             Filenames will be parsed as sample names.
+
+Options:
+  -p, --profiler [bracken|centrifuge|diamond|kaiju|kraken2|krakenuniq|megan6|metaphlan|motus]
+                                  The taxonomic profiler used. All provided
+                                  profiles must come from the same tool!
+                                  [required]
+  -s, --samplesheet FILE          A table with a header and two columns: the
+                                  first column named 'sample' which can be any
+                                  string and the second column named 'profile'
+                                  which must be a file path to an actual
+                                  taxonomic abundance profile. If this option
+                                  is provided, any arguments are ignored.
+  --samplesheet-format [TSV|CSV|ODS|XLSX|arrow|parquet]
+                                  The file format of the sample sheet.
+                                  Depending on the choice, additional package
+                                  dependencies may apply. Will be parsed from
+                                  the sample sheet file name but can be set
+                                  explicitly.
+  -o, --output PATH               The desired output file. By default, the
+                                  file extension will be used to determine the
+                                  output format.  [required]
+  --output-format [TSV|CSV|ODS|XLSX|arrow|parquet|BIOM]
+                                  The desired output format. Depending on the
+                                  choice, additional package dependencies may
+                                  apply. Will be parsed from the output file
+                                  name but can be set explicitly.
+  --wide / --long                 Output merged abundance data in either wide
+                                  or (tidy) long format. Ignored when the
+                                  desired output format is BIOM.  [default:
+                                  wide]
+  --summarise-at, --summarize-at TEXT
+                                  Summarise abundance profiles at higher
+                                  taxonomic rank. The provided option must
+                                  match a rank in the taxonomy exactly. This
+                                  is akin to the clade assigned reads provided
+                                  by, for example, kraken2, where the
+                                  abundances of a whole taxonomic branch are
+                                  assigned to a taxon at the desired rank.
+                                  Please note that abundances above the
+                                  selected rank are simply ignored. No attempt
+                                  is made to redistribute those down to the
+                                  desired rank. Some tools, like Bracken, were
+                                  designed for this purpose but it doesn't
+                                  seem like a problem we can generally solve
+                                  here.
+  --taxonomy PATH                 The path to a directory containing taxdump
+                                  files. At least nodes.dmp and names.dmp are
+                                  required. A merged.dmp file is optional.
+  --add-name                      Add the taxon name to the output.
+  --add-rank                      Add the taxon rank to the output.
+  --add-lineage                   Add the taxon's entire lineage to the
+                                  output. These are taxon names separated by
+                                  semi-colons.
+  --add-id-lineage                Add the taxon's entire lineage to the
+                                  output. These are taxon identifiers
+                                  separated by semi-colons.
+  -h, --help                      Show this message and exit.

--- a/docs/quick_reference/standardise_help.txt
+++ b/docs/quick_reference/standardise_help.txt
@@ -1,78 +1,45 @@
-                                                                                              
- Usage: taxpasta standardise [OPTIONS] PROFILE                                                
-                                                                                              
- Standardise a taxonomic profile (alias: 'standardize').                                      
-                                                                                              
-╭─ Arguments ────────────────────────────────────────────────────────────────────────────────╮
-│ *    profile      PATH  A file containing a taxonomic profile. [required]                  │
-╰────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ──────────────────────────────────────────────────────────────────────────────────╮
-│ *  --profiler                 -p      [bracken|centrifuge|diamo  The taxonomic profiler    │
-│                                       nd|kaiju|kraken2|krakenun  used.                     │
-│                                       iq|megan6|metaphlan|motus  [required]                │
-│                                       ]                                                    │
-│ *  --output                   -o      PATH                       The desired output file.  │
-│                                                                  By default, the file      │
-│                                                                  extension will be used to │
-│                                                                  determine the output      │
-│                                                                  format.                   │
-│                                                                  [required]                │
-│    --output-format                    [TSV|CSV|ODS|XLSX|arrow|p  The desired output        │
-│                                       arquet]                    format. Depending on the  │
-│                                                                  choice, additional        │
-│                                                                  package dependencies may  │
-│                                                                  apply. Will be parsed     │
-│                                                                  from the output file name │
-│                                                                  but can be set            │
-│                                                                  explicitly.               │
-│                                                                  [default: None]           │
-│    --summarise-at,--summari…          TEXT                       Summarise abundance       │
-│                                                                  profiles at higher        │
-│                                                                  taxonomic rank. The       │
-│                                                                  provided option must      │
-│                                                                  match a rank in the       │
-│                                                                  taxonomy exactly. This is │
-│                                                                  akin to the clade         │
-│                                                                  assigned reads provided   │
-│                                                                  by, for example, kraken2, │
-│                                                                  where the abundances of a │
-│                                                                  whole taxonomic branch    │
-│                                                                  are assigned to a taxon   │
-│                                                                  at the desired rank.      │
-│                                                                  Please note that          │
-│                                                                  abundances above the      │
-│                                                                  selected rank are simply  │
-│                                                                  ignored. No attempt is    │
-│                                                                  made to redistribute      │
-│                                                                  those down to the desired │
-│                                                                  rank. Some tools, like    │
-│                                                                  Bracken, were designed    │
-│                                                                  for this purpose but it   │
-│                                                                  doesn't seem like a       │
-│                                                                  problem we can generally  │
-│                                                                  solve here.               │
-│                                                                  [default: None]           │
-│    --taxonomy                         PATH                       The path to a directory   │
-│                                                                  containing taxdump files. │
-│                                                                  At least nodes.dmp and    │
-│                                                                  names.dmp are required. A │
-│                                                                  merged.dmp file is        │
-│                                                                  optional.                 │
-│                                                                  [default: None]           │
-│    --add-name                                                    Add the taxon name to the │
-│                                                                  output.                   │
-│    --add-rank                                                    Add the taxon rank to the │
-│                                                                  output.                   │
-│    --add-lineage                                                 Add the taxon's entire    │
-│                                                                  lineage to the output.    │
-│                                                                  These are taxon names     │
-│                                                                  separated by semi-colons. │
-│    --add-id-lineage                                              Add the taxon's entire    │
-│                                                                  lineage to the output.    │
-│                                                                  These are taxon           │
-│                                                                  identifiers separated by  │
-│                                                                  semi-colons.              │
-│    --help                     -h                                 Show this message and     │
-│                                                                  exit.                     │
-╰────────────────────────────────────────────────────────────────────────────────────────────╯
+Usage: taxpasta standardise [OPTIONS] PROFILE
 
+  Standardise a taxonomic profile (alias: 'standardize').
+
+Arguments:
+  PROFILE  A file containing a taxonomic profile.  [required]
+
+Options:
+  -p, --profiler [bracken|centrifuge|diamond|kaiju|kraken2|krakenuniq|megan6|metaphlan|motus]
+                                  The taxonomic profiler used.  [required]
+  -o, --output PATH               The desired output file. By default, the
+                                  file extension will be used to determine the
+                                  output format.  [required]
+  --output-format [TSV|CSV|ODS|XLSX|arrow|parquet]
+                                  The desired output format. Depending on the
+                                  choice, additional package dependencies may
+                                  apply. Will be parsed from the output file
+                                  name but can be set explicitly.
+  --summarise-at, --summarize-at TEXT
+                                  Summarise abundance profiles at higher
+                                  taxonomic rank. The provided option must
+                                  match a rank in the taxonomy exactly. This
+                                  is akin to the clade assigned reads provided
+                                  by, for example, kraken2, where the
+                                  abundances of a whole taxonomic branch are
+                                  assigned to a taxon at the desired rank.
+                                  Please note that abundances above the
+                                  selected rank are simply ignored. No attempt
+                                  is made to redistribute those down to the
+                                  desired rank. Some tools, like Bracken, were
+                                  designed for this purpose but it doesn't
+                                  seem like a problem we can generally solve
+                                  here.
+  --taxonomy PATH                 The path to a directory containing taxdump
+                                  files. At least nodes.dmp and names.dmp are
+                                  required. A merged.dmp file is optional.
+  --add-name                      Add the taxon name to the output.
+  --add-rank                      Add the taxon rank to the output.
+  --add-lineage                   Add the taxon's entire lineage to the
+                                  output. These are taxon names separated by
+                                  semi-colons.
+  --add-id-lineage                Add the taxon's entire lineage to the
+                                  output. These are taxon identifiers
+                                  separated by semi-colons.
+  -h, --help                      Show this message and exit.

--- a/docs/tutorials/tutorial_bash_snippets.md
+++ b/docs/tutorials/tutorial_bash_snippets.md
@@ -101,9 +101,7 @@ head 2612_pe-ERR5766176-db1.kraken2.report.txt
 taxpasta standardise -p kraken2 -o 2612_pe-ERR5766176-db1_kraken2.tsv 2612_pe-ERR5766176-db1.kraken2.report.txt
 ```
 
-    [13:40:04] INFO     Write result to                           d=780946;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/infrastructure/cli/standardise.py\standardise.py;;\:d=524953;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/infrastructure/cli/standardise.py#264\264;;\
-
-                        '2612_pe-ERR5766176-db1_kraken2.tsv'.
+    [INFO] Write result to '2612_pe-ERR5766176-db1_kraken2.tsv'.
 
 <!-- --8<-- [end:standardise] -->
 <!-- --8<-- [start:standardise-head] -->
@@ -139,17 +137,9 @@ head 2612_pe-ERR5766176-db1_kraken2.tsv
 taxpasta merge -p motus -o dbMOTUs_motus.tsv 2612_pe-ERR5766176-db_mOTU.out 2612_se-ERR5766180-db_mOTU.out
 ```
 
-    [13:40:05] WARNING  The merged profiles        d=281136;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/application/sample_merging_application.py\sample_merging_application.py;;\:d=298902;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/application/sample_merging_application.py#116\116;;\
+    [WARNING] The merged profiles contained different taxa. Additional zeroes were introduced for missing taxa.
 
-                        contained different taxa.
-
-                        Additional zeroes were
-
-                        introduced for missing
-
-                        taxa.
-
-               INFO     Write result to 'dbMOTUs_motus.tsv'.            d=632786;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/infrastructure/cli/merge.py\merge.py;;\:d=930027;file:///home/moritz/Codebase/taxprofiler/taxpasta/src/taxpasta/infrastructure/cli/merge.py#448\448;;\
+    [INFO] Write result to 'dbMOTUs_motus.tsv'.
 
 <!-- --8<-- [end:merge] -->
 <!-- --8<-- [start:merge-head] -->

--- a/src/taxpasta/infrastructure/cli/merge.py
+++ b/src/taxpasta/infrastructure/cli/merge.py
@@ -301,7 +301,7 @@ def merge(
         "identifiers separated by semi-colons.",
     ),
 ) -> None:
-    """Standardise and merge two or more taxonomic profiles into a single table."""
+    """Standardise and merge two or more taxonomic profiles."""
     # Perform input validation.
     valid_output_format: Union[
         TidyObservationTableFileFormat, WideObservationTableFileFormat


### PR DESCRIPTION
Removes some of the odd output generated by quarto/pandoc with the rich logger.
