### PR TITLE
Fix all links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed a few broken internal links (#89)
+
 ## [0.3.0] - (2023-04-01)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ taxonomic tables for:
 -   [MetaPhlAn](https://segatalab.cibio.unitn.it/tools/metaphlan/index.html)
 -   [mOTUs](https://motu-tool.org/)
 
-See [supported profilers](/supported_profilers/)
+See [supported profilers](https://taxpasta.readthedocs.io/en/latest/supported_profilers/)
 for more information.
 
 ## Install
@@ -93,7 +93,7 @@ taxpasta -h
 
 Taxpasta currently offers two commands corresponding to the main
 [use-cases](#about). You can find out more in the [commands'
-documentation](/commands).
+documentation](https://taxpasta.readthedocs.io/en/latest/commands).
 
 ### Standardise
 
@@ -117,7 +117,7 @@ With these minimal arguments, taxpasta produces a two column output consisting o
 You can count on the second column being integers :wink:. Having such a simple
 and tidy table should make your downstream analysis much smoother to start out
 with. Please have a look at the full [getting
-started](/tutorials/getting-started)
+started](https://taxpasta.readthedocs.io/en/latest/tutorials/getting-started)
 tutorial for a more thorough introduction.
 
 ### Merge
@@ -136,7 +136,7 @@ taxpasta merge -p metaphlan -o merged.tsv MOCK_*.metaphlan3_profile.txt
 The output of the `merge` command has one column for the taxonomic identifier and
 one more column for each input profile. Again, have a look at the full
 [getting
-started](/tutorials/getting-started)
+started](https://taxpasta.readthedocs.io/en/latest/tutorials/getting-started)
 tutorial for a more thorough introduction.
 
 ## Copyright

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ taxonomic tables for:
 -   [MetaPhlAn](https://segatalab.cibio.unitn.it/tools/metaphlan/index.html)
 -   [mOTUs](https://motu-tool.org/)
 
-See [supported profilers](https://taxpasta.readthedocs.io/en/latest/supported_profilers/)
+See [supported profilers](/supported_profilers/)
 for more information.
 
 ## Install
@@ -93,7 +93,7 @@ taxpasta -h
 
 Taxpasta currently offers two commands corresponding to the main
 [use-cases](#about). You can find out more in the [commands'
-documentation](https://taxpasta.readthedocs.io/en/latest/commands/).
+documentation](/commands).
 
 ### Standardise
 
@@ -117,7 +117,7 @@ With these minimal arguments, taxpasta produces a two column output consisting o
 You can count on the second column being integers :wink:. Having such a simple
 and tidy table should make your downstream analysis much smoother to start out
 with. Please have a look at the full [getting
-started](https://taxpasta.readthedocs.io/en/latest/tutorials/getting-started.md)
+started](/tutorials/getting-started)
 tutorial for a more thorough introduction.
 
 ### Merge
@@ -136,7 +136,7 @@ taxpasta merge -p metaphlan -o merged.tsv MOCK_*.metaphlan3_profile.txt
 The output of the `merge` command has one column for the taxonomic identifier and
 one more column for each input profile. Again, have a look at the full
 [getting
-started](https://taxpasta.readthedocs.io/en/latest/tutorials/getting-started.md)
+started](/tutorials/getting-started)
 tutorial for a more thorough introduction.
 
 ## Copyright

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -4,5 +4,5 @@ Taxpasta offers multiple commands that perform different functionality.
 
 The following pages document the 'what, how, and why' for each command.
 
--   [`taxpasta standardise`](standardise.md)
--   [`taxpasta merge`](merge.md)
+-   [`taxpasta standardise`](standardise)
+-   [`taxpasta merge`](merge)

--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -13,7 +13,7 @@ in one go and have all profiles combined into a single table. You will
 use this command if you want to load the table directly into a spreadsheet
 program or programming language without needing to manually combine profiles.
 
-See [`standardise`](standardise.md) if you wish to only standardise without merging.
+See [`standardise`](standardise) if you wish to only standardise without merging.
 
 !!! warning
 

--- a/docs/commands/standardise.md
+++ b/docs/commands/standardise.md
@@ -12,7 +12,7 @@ You should use `taxpasta standardise` when you want to standardise a single
 taxonomic profile or multiple profiles independently but do not want to merge
 them in a single table, for example, you wish to store them separately to merge them yourself in the future.
 
-See [`merge`](merge.md) if you wish to both standardise and merge in one step to
+See [`merge`](merge) if you wish to both standardise and merge in one step to
 generate a single table containing all samples.
 
 !!! warning

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -5,7 +5,7 @@ questions on the nf-core [Slack
 channel](https://nfcore.slack.com/archives/C031QH57DSS) or in GitHub issues,
 writing documentation and providing examples, testing the software in various
 settings, or submitting code through pull requests. A different, but very important
-way of contributing is to [support new taxonomic profilers](supporting_new_profiler.md).
+way of contributing is to [support new taxonomic profilers](/contributing/supporting_new_profiler).
 
 ## Example Contributions
 
@@ -114,7 +114,15 @@ local development.
     tox -p auto
     ```
 
-6. Commit your changes and push your branch to GitHub. Please use [semantic
+6. To render docs locally, change into docs and serve the pages
+
+    ```shell
+    cd docs/
+    mkdocs build --clean
+    mkdocs serve
+    ```
+
+7. Commit your changes and push your branch to GitHub. Please use [semantic
    commit messages](https://www.conventionalcommits.org/).
 
     ```shell
@@ -123,7 +131,7 @@ local development.
     git push origin fix-name-of-your-bugfix
     ```
 
-7. Open the link displayed in the message when pushing your new branch in order
+8. Open the link displayed in the message when pushing your new branch in order
    to submit a pull request.
 
 ### Pull Request Guidelines

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ taxonomic tables for:
 -   [MetaPhlAn](https://segatalab.cibio.unitn.it/tools/metaphlan/index.html)
 -   [mOTUs](https://motu-tool.org/)
 
-See [supported profilers](supported_profilers/index) for more information.
+See [supported profilers](/supported_profilers) for more information.
 
 ## Install
 
@@ -85,7 +85,7 @@ taxpasta -h
 ```
 
 Taxpasta currently offers two commands corresponding to the main [use-cases](#about).
-You can find out more in the [commands' documentation](commands/index.md).
+You can find out more in the [commands' documentation](/commands).
 
 ### Standardise
 
@@ -109,7 +109,7 @@ With these minimal arguments, taxpasta produces a two column output consisting o
 You can count on the second column being integers :wink: Having such a simple
 and tidy table should make your downstream analysis much smoother to start out
 with. Please, have a look at the full [getting
-started](tutorials/getting-started.md) tutorial for a more thorough
+started](/tutorials/getting-started) tutorial for a more thorough
 introduction.
 
 ### Merge
@@ -127,7 +127,7 @@ taxpasta merge -p metaphlan -o merged.tsv MOCK_*.metaphlan3_profile.txt
 
 The output of the `merge` command has one column for the taxonomy identifier and
 one more column for each input profile. Again, please have a look at the full
-[getting started](tutorials/getting-started.md) tutorial for a more thorough
+[getting started](/tutorials/getting-started) tutorial for a more thorough
 introduction.
 
 ## Copyright

--- a/docs/quick_reference/index.md
+++ b/docs/quick_reference/index.md
@@ -2,5 +2,5 @@
 
 The following pages provide the `help` messages of each command to act as a quick reference for how to use them.
 
--   [`taxpasta standardise`](standardise.md)
--   [`taxpasta merge`](merge.md)
+-   [`taxpasta standardise`](standardise)
+-   [`taxpasta merge`](merge)

--- a/docs/supported_profilers/index.md
+++ b/docs/supported_profilers/index.md
@@ -7,16 +7,16 @@ each taxonomic profiler can be standardised by taxpasta.
 
     In particular, when comparing results between various tools, please be very
     aware of their differences.  In the document on
-    [terminology](terminology.md), we describe how we think about the different
+    [terminology](terminology), we describe how we think about the different
     tools. Spending some time on considering the consequences now, will save
     you a lot of headache and prevent potentially wrong results later.
 
--   [Bracken](bracken.md)
--   [Centrifuge](centrifuge.md)
--   [DIAMOND](diamond.md)
--   [Kaiju](kaiju.md)
--   [Kraken2](kraken2.md)
--   [KrakenUniq](krakenuniq.md)
--   [MEGAN6/MALT](megan6.md)
--   [MetaPhlAn](metaphlan.md)
--   [mOTUs](motus.md)
+-   [Bracken](bracken)
+-   [Centrifuge](centrifuge)
+-   [DIAMOND](diamond)
+-   [Kaiju](kaiju)
+-   [Kraken2](kraken2)
+-   [KrakenUniq](krakenuniq)
+-   [MEGAN6/MALT](megan6)
+-   [MetaPhlAn](metaphlan)
+-   [mOTUs](motus)


### PR DESCRIPTION
Some internal links were malformed resulting in (ugly) 404

Namely, you don't want to refer to internal links via their `.md` suffix, as you want to link to the back-end rendered HTML version. So I've removed the `.md` where found.

Also found a couple of links that were using hard URLs rather than internal, so I've replaced them.

* [x] fix #88 
* [x] description of feature/fix
* [x] tests added/passed (clicked through every internal link I could find)
* [x] add an entry to the [changelog](../CHANGELOG.md)
