### PR TITLE
Warn compositionality

### DIFF
--- a/src/taxpasta/infrastructure/application/centrifuge/centrifuge_profile.py
+++ b/src/taxpasta/infrastructure/application/centrifuge/centrifuge_profile.py
@@ -26,6 +26,10 @@ from pandera.typing import Series
 from taxpasta.infrastructure.helpers import BaseDataFrameModel
 
 
+CENTRIFUGE_PERCENT_TOTAL = 100.0
+CENTRIFUGE_PERCENT_TOLERANCE = 1.0
+
+
 class CentrifugeProfile(BaseDataFrameModel):
     """Define the expected centrifuge profile format."""
 
@@ -36,7 +40,13 @@ class CentrifugeProfile(BaseDataFrameModel):
     taxonomy_id: Series[int] = pa.Field(ge=0)
     name: Series[str] = pa.Field()
 
-    @pa.check("percent", name="compositionality")
+    @pa.check("percent", name="compositionality", raise_warning=True)
     def check_compositionality(cls, percent: Series[float]) -> bool:
         """Check that the percent of 'unclassified' and 'root' add up to a hundred."""
-        return percent.empty or bool(np.isclose(percent[:2].sum(), 100.0, atol=1.0))
+        return percent.empty or bool(
+            np.isclose(
+                percent[:2].sum(),
+                CENTRIFUGE_PERCENT_TOTAL,
+                atol=CENTRIFUGE_PERCENT_TOLERANCE,
+            )
+        )

--- a/src/taxpasta/infrastructure/application/centrifuge/centrifuge_profile_reader.py
+++ b/src/taxpasta/infrastructure/application/centrifuge/centrifuge_profile_reader.py
@@ -51,14 +51,14 @@ class CentrifugeProfileReader(ProfileReader):
             header=None,
             index_col=False,
             skipinitialspace=True,
-            names=[
-                CentrifugeProfile.percent,
-                CentrifugeProfile.clade_assigned_reads,
-                CentrifugeProfile.direct_assigned_reads,
-                CentrifugeProfile.taxonomy_level,
-                CentrifugeProfile.taxonomy_id,
-                CentrifugeProfile.name,
-            ],
         )
         cls._check_num_columns(result, CentrifugeProfile)
+        result.columns = [
+            CentrifugeProfile.percent,
+            CentrifugeProfile.clade_assigned_reads,
+            CentrifugeProfile.direct_assigned_reads,
+            CentrifugeProfile.taxonomy_level,
+            CentrifugeProfile.taxonomy_id,
+            CentrifugeProfile.name,
+        ]
         return result

--- a/src/taxpasta/infrastructure/application/diamond/diamond_profile_reader.py
+++ b/src/taxpasta/infrastructure/application/diamond/diamond_profile_reader.py
@@ -39,12 +39,12 @@ class DiamondProfileReader(ProfileReader):
             sep="\t",
             header=None,
             index_col=False,
-            names=[
-                DiamondProfile.query_id,
-                DiamondProfile.taxonomy_id,
-                DiamondProfile.e_value,
-            ],
-            dtype={DiamondProfile.e_value: float},
+            dtype={2: float},
         )
         cls._check_num_columns(result, DiamondProfile)
+        result.columns = [
+            DiamondProfile.query_id,
+            DiamondProfile.taxonomy_id,
+            DiamondProfile.e_value,
+        ]
         return result

--- a/src/taxpasta/infrastructure/application/ganon/ganon_profile.py
+++ b/src/taxpasta/infrastructure/application/ganon/ganon_profile.py
@@ -27,6 +27,10 @@ from pandera.typing import Series
 from taxpasta.infrastructure.helpers import BaseDataFrameModel
 
 
+GANON_PERCENT_TOTAL = 100.0
+GANON_PERCENT_TOLERANCE = 1.0
+
+
 class GanonProfile(BaseDataFrameModel):
     """Define the expected ganon profile format."""
 
@@ -40,7 +44,7 @@ class GanonProfile(BaseDataFrameModel):
     number_cumulative: Series[int] = pa.Field(ge=0)
     percent_cumulative: Series[float] = pa.Field(ge=0.0, le=100.0)
 
-    @pa.dataframe_check
+    @pa.dataframe_check(name="compositionality", raise_warning=True)
     def check_compositionality(cls, profile: pd.DataFrame) -> bool:
         """Check that the percent of 'unclassified' and 'root' add up to a hundred."""
         # Ganon reports percentage to 5 decimal places, but rounding errors do add up.
@@ -50,7 +54,7 @@ class GanonProfile(BaseDataFrameModel):
                     profile[cls.rank].isin(["unclassified", "root"]),
                     cls.percent_cumulative,
                 ].sum(),
-                100.0,
-                atol=0.1,
+                GANON_PERCENT_TOTAL,
+                atol=GANON_PERCENT_TOLERANCE,
             )
         )

--- a/src/taxpasta/infrastructure/application/ganon/ganon_profile_reader.py
+++ b/src/taxpasta/infrastructure/application/ganon/ganon_profile_reader.py
@@ -51,17 +51,17 @@ class GanonProfileReader(ProfileReader):
             header=None,
             index_col=False,
             skipinitialspace=True,
-            names=[
-                GanonProfile.rank,
-                GanonProfile.target,
-                GanonProfile.lineage,
-                GanonProfile.name,
-                GanonProfile.number_unique,
-                GanonProfile.number_shared,
-                GanonProfile.number_children,
-                GanonProfile.number_cumulative,
-                GanonProfile.percent_cumulative,
-            ],
         )
         cls._check_num_columns(result, GanonProfile)
+        result.columns = [
+            GanonProfile.rank,
+            GanonProfile.target,
+            GanonProfile.lineage,
+            GanonProfile.name,
+            GanonProfile.number_unique,
+            GanonProfile.number_shared,
+            GanonProfile.number_children,
+            GanonProfile.number_cumulative,
+            GanonProfile.percent_cumulative,
+        ]
         return result

--- a/src/taxpasta/infrastructure/application/kaiju/kaiju_profile.py
+++ b/src/taxpasta/infrastructure/application/kaiju/kaiju_profile.py
@@ -27,6 +27,10 @@ from pandera.typing import Series
 from taxpasta.infrastructure.helpers import BaseDataFrameModel
 
 
+KAIJU_PERCENT_TOTAL = 100.0
+KAIJU_PERCENT_TOLERANCE = 1.0
+
+
 class KaijuProfile(BaseDataFrameModel):
     """Define the expected kaiju profile format."""
 
@@ -36,11 +40,13 @@ class KaijuProfile(BaseDataFrameModel):
     taxon_id: Series[pd.Int64Dtype] = pa.Field(nullable=True)
     taxon_name: Series[str] = pa.Field()
 
-    @pa.check("percent", name="compositionality")
+    @pa.check("percent", name="compositionality", raise_warning=True)
     def check_compositionality(cls, percent: Series[float]) -> bool:
         """Check that the percentages add up to a hundred."""
         # Kaiju reports percentages with sixth decimals
-        return percent.empty or bool(np.isclose(percent.sum(), 100.0, atol=1.0))
+        return percent.empty or bool(
+            np.isclose(percent.sum(), KAIJU_PERCENT_TOTAL, atol=KAIJU_PERCENT_TOLERANCE)
+        )
 
     @pa.check("file", name="unique_filename")
     def check_unique_filename(cls, file_col: Series[str]) -> bool:

--- a/src/taxpasta/infrastructure/application/kmcp/kmcp_profile.py
+++ b/src/taxpasta/infrastructure/application/kmcp/kmcp_profile.py
@@ -26,6 +26,10 @@ from pandera.typing import Series
 from taxpasta.infrastructure.helpers import BaseDataFrameModel
 
 
+KMCP_PERCENT_TOTAL = 100.0
+KMCP_PERCENT_TOLERANCE = 1.0
+
+
 class KMCPProfile(BaseDataFrameModel):
     """Define the expected KMCP profile format."""
 
@@ -49,8 +53,12 @@ class KMCPProfile(BaseDataFrameModel):
     taxonomic_path: Series[str] = pa.Field(nullable=True, alias="taxpath")
     taxonomic_path_lineage: Series[str] = pa.Field(nullable=True, alias="taxpathsn")
 
-    @pa.check("percentage", name="compositionality")
+    @pa.check("percentage", name="compositionality", raise_warning=True)
     def check_compositionality(cls, percentage: Series[float]) -> bool:
         """Check that the percentages add up to a hundred."""
         # KMCP profile reports percentages with sixth decimals
-        return percentage.empty or bool(np.isclose(percentage.sum(), 100.0, atol=1.0))
+        return percentage.empty or bool(
+            np.isclose(
+                percentage.sum(), KMCP_PERCENT_TOTAL, atol=KMCP_PERCENT_TOLERANCE
+            )
+        )

--- a/src/taxpasta/infrastructure/application/kraken2/kraken2_profile.py
+++ b/src/taxpasta/infrastructure/application/kraken2/kraken2_profile.py
@@ -29,6 +29,10 @@ from pandera.typing import Series
 from taxpasta.infrastructure.helpers import BaseDataFrameModel
 
 
+KRAKEN2_PERCENT_TOTAL = 100.0
+KRAKEN2_PERCENT_TOLERANCE = 1.0
+
+
 class Kraken2Profile(BaseDataFrameModel):
     """Define the expected kraken2 profile format."""
 
@@ -41,7 +45,7 @@ class Kraken2Profile(BaseDataFrameModel):
     taxonomy_id: Series[int] = pa.Field(ge=0)
     name: Series[str] = pa.Field()
 
-    @pa.dataframe_check
+    @pa.dataframe_check(name="compositionality", raise_warning=True)
     def check_compositionality(cls, profile: pd.DataFrame) -> bool:
         """Check that the percent of 'unclassified' and 'root' add up to a hundred."""
         # Kraken2 reports percentages only to the second decimal, so we expect
@@ -52,7 +56,7 @@ class Kraken2Profile(BaseDataFrameModel):
                 profile.loc[
                     profile[cls.taxonomy_lvl].isin(["U", "R"]), cls.percent
                 ].sum(),
-                100.0,
-                atol=1.0,
+                KRAKEN2_PERCENT_TOTAL,
+                atol=KRAKEN2_PERCENT_TOLERANCE,
             )
         )

--- a/src/taxpasta/infrastructure/application/megan6/megan6_profile_reader.py
+++ b/src/taxpasta/infrastructure/application/megan6/megan6_profile_reader.py
@@ -39,6 +39,7 @@ class Megan6ProfileReader(ProfileReader):
             filepath_or_buffer=profile,
             sep="\t",
             index_col=False,
+            header=None,
         )
         cls._check_num_columns(result, Megan6Profile)
         result.columns = [Megan6Profile.taxonomy_id, Megan6Profile.count]

--- a/src/taxpasta/infrastructure/application/megan6/megan6_profile_reader.py
+++ b/src/taxpasta/infrastructure/application/megan6/megan6_profile_reader.py
@@ -38,8 +38,8 @@ class Megan6ProfileReader(ProfileReader):
         result = pd.read_table(
             filepath_or_buffer=profile,
             sep="\t",
-            names=[Megan6Profile.taxonomy_id, Megan6Profile.count],
             index_col=False,
         )
         cls._check_num_columns(result, Megan6Profile)
+        result.columns = [Megan6Profile.taxonomy_id, Megan6Profile.count]
         return result

--- a/src/taxpasta/infrastructure/application/metaphlan/metaphlan_profile.py
+++ b/src/taxpasta/infrastructure/application/metaphlan/metaphlan_profile.py
@@ -29,6 +29,10 @@ from pandera.typing import Series
 from taxpasta.infrastructure.helpers import BaseDataFrameModel
 
 
+METAPHLAN_PERCENT_TOTAL = 100.0
+METAPHLAN_PERCENT_TOLERANCE = 1.0
+
+
 class MetaphlanProfile(BaseDataFrameModel):
     """Define the expected metaphlan profile format."""
 
@@ -38,7 +42,7 @@ class MetaphlanProfile(BaseDataFrameModel):
     relative_abundance: Series[float] = pa.Field(ge=0.0, le=100.0)
     additional_species: Optional[Series[str]] = pa.Field(nullable=True)
 
-    @pa.dataframe_check
+    @pa.dataframe_check(name="compositionality", raise_warning=True)
     def check_compositionality(cls, profile: pd.DataFrame) -> bool:
         """Check that the percentages per rank add up to a hundred."""
         # Parse the rank from the given lineage.
@@ -46,7 +50,7 @@ class MetaphlanProfile(BaseDataFrameModel):
         return profile.empty or bool(
             np.allclose(
                 profile.groupby(rank, sort=False)[cls.relative_abundance].sum(),
-                100.0,
-                atol=1.0,
+                METAPHLAN_PERCENT_TOTAL,
+                atol=METAPHLAN_PERCENT_TOLERANCE,
             )
         )

--- a/src/taxpasta/infrastructure/application/metaphlan/metaphlan_profile_reader.py
+++ b/src/taxpasta/infrastructure/application/metaphlan/metaphlan_profile_reader.py
@@ -46,15 +46,15 @@ class MetaphlanProfileReader(ProfileReader):
             skiprows=num_header_lines,
             header=None,
             index_col=False,
-            names=[
-                MetaphlanProfile.clade_name,
-                MetaphlanProfile.ncbi_tax_id,
-                MetaphlanProfile.relative_abundance,
-                MetaphlanProfile.additional_species,
-            ],
-            dtype={MetaphlanProfile.ncbi_tax_id: str},
+            dtype={1: str},
         )
         cls._check_num_columns(result, MetaphlanProfile)
+        result.columns = [
+            MetaphlanProfile.clade_name,
+            MetaphlanProfile.ncbi_tax_id,
+            MetaphlanProfile.relative_abundance,
+            MetaphlanProfile.additional_species,
+        ]
         return result
 
     @classmethod

--- a/src/taxpasta/infrastructure/application/motus/motus_profile_reader.py
+++ b/src/taxpasta/infrastructure/application/motus/motus_profile_reader.py
@@ -40,13 +40,13 @@ class MotusProfileReader(ProfileReader):
             sep="\t",
             skiprows=3,
             header=None,
-            names=[
-                MotusProfile.consensus_taxonomy,
-                MotusProfile.ncbi_tax_id,
-                MotusProfile.read_count,
-            ],
             index_col=False,
-            dtype={MotusProfile.ncbi_tax_id: "Int64"},
+            dtype={1: "Int64"},
         )
         cls._check_num_columns(result, MotusProfile)
+        result.columns = [
+            MotusProfile.consensus_taxonomy,
+            MotusProfile.ncbi_tax_id,
+            MotusProfile.read_count,
+        ]
         return result

--- a/tests/integration/test_bracken_etl.py
+++ b/tests/integration/test_bracken_etl.py
@@ -71,6 +71,7 @@ def other_profile(data_dir: Path, request: pytest.FixtureRequest) -> Path:
         ),
     ],
 )
+@pytest.mark.filterwarnings("error")
 def test_bracken_etl(
     bracken_data_dir: Path,
     filename: str,

--- a/tests/integration/test_bracken_etl.py
+++ b/tests/integration/test_bracken_etl.py
@@ -71,7 +71,7 @@ def other_profile(data_dir: Path, request: pytest.FixtureRequest) -> Path:
         ),
     ],
 )
-@pytest.mark.filterwarnings("error")
+@pytest.mark.filterwarnings("error::UserWarning")
 def test_bracken_etl(
     bracken_data_dir: Path,
     filename: str,

--- a/tests/integration/test_diamond_etl.py
+++ b/tests/integration/test_diamond_etl.py
@@ -22,6 +22,7 @@
 from pathlib import Path
 
 import pytest
+from pandas.errors import ParserError
 from pandera.errors import SchemaErrors
 
 from taxpasta.application.error import StandardisationError
@@ -60,11 +61,11 @@ def other_profile(data_dir: Path, request: pytest.FixtureRequest) -> Path:
         "diamond_valid_2.tsv",
         pytest.param(
             "diamond_invalid_1.tsv",
-            marks=pytest.mark.raises(exception=SchemaErrors),
+            marks=pytest.mark.raises(exception=ParserError),
         ),
         pytest.param(
             "diamond_invalid_2.tsv",
-            marks=pytest.mark.raises(exception=SchemaErrors),
+            marks=pytest.mark.raises(exception=ParserError),
         ),
     ],
 )

--- a/tests/integration/test_ganon_etl.py
+++ b/tests/integration/test_ganon_etl.py
@@ -59,7 +59,7 @@ def other_profile(data_dir: Path, request: pytest.FixtureRequest) -> Path:
         "2612_pe_ERR5766176_db1.ganon.tre",
         pytest.param(
             "invalid_2612_pe_ERR5766176_db1.ganon_missing_column.tre",
-            marks=pytest.mark.raises(exception=SchemaErrors),
+            marks=pytest.mark.raises(exception=ValueError),
         ),
     ],
 )

--- a/tests/integration/test_kaiju_etl.py
+++ b/tests/integration/test_kaiju_etl.py
@@ -64,7 +64,7 @@ def other_profile(data_dir: Path, request: pytest.FixtureRequest) -> Path:
         ),
     ],
 )
-@pytest.mark.filterwarnings("error")
+@pytest.mark.filterwarnings("error::UserWarning")
 def test_kaiju_etl(
     kaiju_data_dir: Path,
     filename: str,

--- a/tests/integration/test_kaiju_etl.py
+++ b/tests/integration/test_kaiju_etl.py
@@ -64,6 +64,7 @@ def other_profile(data_dir: Path, request: pytest.FixtureRequest) -> Path:
         ),
     ],
 )
+@pytest.mark.filterwarnings("error")
 def test_kaiju_etl(
     kaiju_data_dir: Path,
     filename: str,

--- a/tests/integration/test_kraken2_etl.py
+++ b/tests/integration/test_kraken2_etl.py
@@ -71,6 +71,7 @@ def other_profile(data_dir: Path, request: pytest.FixtureRequest) -> Path:
         ),
     ],
 )
+@pytest.mark.filterwarnings("error")
 def test_kraken2_etl(
     kraken2_data_dir: Path,
     filename: str,

--- a/tests/integration/test_kraken2_etl.py
+++ b/tests/integration/test_kraken2_etl.py
@@ -71,7 +71,7 @@ def other_profile(data_dir: Path, request: pytest.FixtureRequest) -> Path:
         ),
     ],
 )
-@pytest.mark.filterwarnings("error")
+@pytest.mark.filterwarnings("error::UserWarning")
 def test_kraken2_etl(
     kraken2_data_dir: Path,
     filename: str,

--- a/tests/integration/test_metaphlan_etl.py
+++ b/tests/integration/test_metaphlan_etl.py
@@ -86,7 +86,7 @@ def test_valid_profile_etl(
     )
 
 
-@pytest.mark.filterwarnings("error")
+@pytest.mark.filterwarnings("error::UserWarning")
 def test_invalid_profile_etl(
     invalid_metaphlan_profile: Path,
 ):

--- a/tests/integration/test_metaphlan_etl.py
+++ b/tests/integration/test_metaphlan_etl.py
@@ -86,6 +86,7 @@ def test_valid_profile_etl(
     )
 
 
+@pytest.mark.filterwarnings("error")
 def test_invalid_profile_etl(
     invalid_metaphlan_profile: Path,
 ):

--- a/tests/unit/infrastructure/application/bracken/test_bracken_profile.py
+++ b/tests/unit/infrastructure/application/bracken/test_bracken_profile.py
@@ -159,7 +159,7 @@ def test_column_presence(profile: pd.DataFrame):
         ),
     ],
 )
-@pytest.mark.filterwarnings("error")
+@pytest.mark.filterwarnings("error::UserWarning")
 def test_fraction_total_reads(profile: pd.DataFrame):
     """Test that the fraction column is checked."""
     BrackenProfile.validate(profile)

--- a/tests/unit/infrastructure/application/bracken/test_bracken_profile.py
+++ b/tests/unit/infrastructure/application/bracken/test_bracken_profile.py
@@ -159,6 +159,7 @@ def test_column_presence(profile: pd.DataFrame):
         ),
     ],
 )
+@pytest.mark.filterwarnings("error")
 def test_fraction_total_reads(profile: pd.DataFrame):
     """Test that the fraction column is checked."""
     BrackenProfile.validate(profile)

--- a/tests/unit/infrastructure/application/centrifuge/test_centrifuge_profile.py
+++ b/tests/unit/infrastructure/application/centrifuge/test_centrifuge_profile.py
@@ -135,6 +135,7 @@ def test_column_presence(profile: pd.DataFrame):
         ),
     ],
 )
+@pytest.mark.filterwarnings("error")
 def test_percent(profile: pd.DataFrame):
     """Test that the percent column is checked."""
     CentrifugeProfile.validate(profile)

--- a/tests/unit/infrastructure/application/centrifuge/test_centrifuge_profile.py
+++ b/tests/unit/infrastructure/application/centrifuge/test_centrifuge_profile.py
@@ -135,7 +135,7 @@ def test_column_presence(profile: pd.DataFrame):
         ),
     ],
 )
-@pytest.mark.filterwarnings("error")
+@pytest.mark.filterwarnings("error::UserWarning")
 def test_percent(profile: pd.DataFrame):
     """Test that the percent column is checked."""
     CentrifugeProfile.validate(profile)

--- a/tests/unit/infrastructure/application/ganon/test_ganon_profile.py
+++ b/tests/unit/infrastructure/application/ganon/test_ganon_profile.py
@@ -128,7 +128,7 @@ def test_column_presence(profile: pd.DataFrame):
                 )
             ),
             marks=pytest.mark.raises(
-                exception=SchemaError, message="check_compositionality"
+                exception=SchemaError, message="<Check compositionality>"
             ),
         ),
         pytest.param(
@@ -148,11 +148,12 @@ def test_column_presence(profile: pd.DataFrame):
                 )
             ),
             marks=pytest.mark.raises(
-                exception=SchemaError, message="check_compositionality"
+                exception=SchemaError, message="<Check compositionality>"
             ),
         ),
     ],
 )
+@pytest.mark.filterwarnings("error")
 def test_percent(profile: pd.DataFrame):
     """Test that the percent column (percent_cumulative) is checked."""
     GanonProfile.validate(profile)

--- a/tests/unit/infrastructure/application/ganon/test_ganon_profile.py
+++ b/tests/unit/infrastructure/application/ganon/test_ganon_profile.py
@@ -153,7 +153,7 @@ def test_column_presence(profile: pd.DataFrame):
         ),
     ],
 )
-@pytest.mark.filterwarnings("error")
+@pytest.mark.filterwarnings("error::UserWarning")
 def test_percent(profile: pd.DataFrame):
     """Test that the percent column (percent_cumulative) is checked."""
     GanonProfile.validate(profile)

--- a/tests/unit/infrastructure/application/kaiju/test_kaiju_profile.py
+++ b/tests/unit/infrastructure/application/kaiju/test_kaiju_profile.py
@@ -143,6 +143,7 @@ def test_column_presence(profile: pd.DataFrame):
         ),
     ],
 )
+@pytest.mark.filterwarnings("error")
 def test_percent(profile: pd.DataFrame):
     """Test that the percent column is checked."""
     KaijuProfile.validate(profile)

--- a/tests/unit/infrastructure/application/kaiju/test_kaiju_profile.py
+++ b/tests/unit/infrastructure/application/kaiju/test_kaiju_profile.py
@@ -143,7 +143,7 @@ def test_column_presence(profile: pd.DataFrame):
         ),
     ],
 )
-@pytest.mark.filterwarnings("error")
+@pytest.mark.filterwarnings("error::UserWarning")
 def test_percent(profile: pd.DataFrame):
     """Test that the percent column is checked."""
     KaijuProfile.validate(profile)

--- a/tests/unit/infrastructure/application/kmcp/test_kmcp_profile.py
+++ b/tests/unit/infrastructure/application/kmcp/test_kmcp_profile.py
@@ -171,6 +171,7 @@ def test_column_presence(profile: pd.DataFrame):
         ),
     ],
 )
+@pytest.mark.filterwarnings("error")
 def test_percent(profile: pd.DataFrame):
     """Test that the percent column (percent_cumulative) is checked."""
     KMCPProfile.validate(profile)

--- a/tests/unit/infrastructure/application/kmcp/test_kmcp_profile.py
+++ b/tests/unit/infrastructure/application/kmcp/test_kmcp_profile.py
@@ -171,7 +171,7 @@ def test_column_presence(profile: pd.DataFrame):
         ),
     ],
 )
-@pytest.mark.filterwarnings("error")
+@pytest.mark.filterwarnings("error::UserWarning")
 def test_percent(profile: pd.DataFrame):
     """Test that the percent column (percent_cumulative) is checked."""
     KMCPProfile.validate(profile)

--- a/tests/unit/infrastructure/application/kraken2/test_kraken2_profile.py
+++ b/tests/unit/infrastructure/application/kraken2/test_kraken2_profile.py
@@ -164,6 +164,7 @@ def test_column_presence(profile: pd.DataFrame):
         ),
     ],
 )
+@pytest.mark.filterwarnings("error")
 def test_percent(profile: pd.DataFrame):
     """Test that the percent column is checked."""
     Kraken2Profile.validate(profile)

--- a/tests/unit/infrastructure/application/kraken2/test_kraken2_profile.py
+++ b/tests/unit/infrastructure/application/kraken2/test_kraken2_profile.py
@@ -164,7 +164,7 @@ def test_column_presence(profile: pd.DataFrame):
         ),
     ],
 )
-@pytest.mark.filterwarnings("error")
+@pytest.mark.filterwarnings("error::UserWarning")
 def test_percent(profile: pd.DataFrame):
     """Test that the percent column is checked."""
     Kraken2Profile.validate(profile)


### PR DESCRIPTION
Validation failures when checking compositionality now emit warnings instead of errors. The reasoning behind this change is that taxpasta should only normalize given profiles, as long as a profile is of expected format. However, we still warn about this for user information.

* [x] fix #143 
* [x] description of feature/fix
* [x] tests added/passed
* [ ] add an entry to the [changelog](../CHANGELOG.md)
