### PR TITLE
Fix mistake in docs for KrakenUniq regarding which parameter to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-   Fixed mistake in KrakenUniq 'supported profilers' page, where the wrong parameter
+    was listed in regards to which output file is supported by taxpasta (#152)
+
 ## [0.7.0] - (2024-06-08)
 
 ### Changed

--- a/docs/supported_profilers/krakenuniq.md
+++ b/docs/supported_profilers/krakenuniq.md
@@ -4,7 +4,7 @@
 
 ## Profile Format
 
-Taxpasta expects a 9 column table. This file is generated with the KrakenUniq parameter `--output`. The accepted format is:
+Taxpasta expects a 9 column table. This file is generated with the KrakenUniq parameter `--report-file`. The accepted format is:
 
 | Column Header | Description |
 | ------------- | ----------- |


### PR DESCRIPTION
I included in the docs the wrong KrakenUniq parameter to create the right file for taxpasta, this corrects this.

I double checked this by downloading a 'report' file from the nf-core/taxprofiler [AWS results](https://nf-co.re/taxprofiler/1.1.8/results/taxprofiler/results-5d3ee5513a84f92773c8376c55b5f4da39835307/krakenuniq/krakenuniq-db/?file=MOCK_001_Illumina_Hiseq_3000_1.krakenuniq.report.txt), and gave it to latest version of taxpasta.