### PR TITLE
Change pandas and pandera dependencies to exact versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Fixed mistake in KrakenUniq 'supported profilers' page, where the wrong parameter
     was listed in regards to which output file is supported by taxpasta (#152)
 -   Pin maximum python version to prevent issues validating correct file structure (#159)
-    to correctly validate file structure (#159)
 
 ## [0.7.0] - (2024-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Fixed mistake in KrakenUniq 'supported profilers' page, where the wrong parameter
     was listed in regards to which output file is supported by taxpasta (#152)
+-   Pin dependencies to prevent problems with pandera and pandas not being able
+    to correctly validate file structure (#159)
 
 ## [0.7.0] - (2024-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Fixed mistake in KrakenUniq 'supported profilers' page, where the wrong parameter
     was listed in regards to which output file is supported by taxpasta (#152)
--   Pin dependencies to prevent problems with pandera and pandas not being able
+-   Pin maximum python version to prevent issues validating correct file structure (#159)
     to correctly validate file structure (#159)
 
 ## [0.7.0] - (2024-06-08)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ authors = [
 ]
 license = "Apache-2.0"
 readme = { "file" = "README.md", "content-type" = "text/markdown" }
-requires-python = ">=3.9"
+requires-python = ">=3.9,<=3.13"
 # Please consult https://pypi.org/classifiers/ for a full list.
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -52,8 +52,8 @@ dynamic = ["version"]
 dependencies = [
     "depinfo ~=2.2",
     "numpy ~=1.26",
-    "pandas >=2.1",
-    "pandera ==0.26",
+    "pandas ~=2.1",
+    "pandera ~=0.26",
     "taxopy ~=0.13",
     "typer ~=0.16",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dynamic = ["version"]
 dependencies = [
     "depinfo ~=2.2",
     "numpy ~=1.26",
-    "pandas ==2.1",
+    "pandas >=2.1",
     "pandera ==0.26",
     "taxopy ~=0.13",
     "typer ~=0.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,8 @@ dynamic = ["version"]
 dependencies = [
     "depinfo ~=2.2",
     "numpy ~=1.26",
-    "pandas ~=2.1",
-    "pandera ~=0.26",
+    "pandas ==2.1",
+    "pandera ==0.26",
     "taxopy ~=0.13",
     "typer ~=0.16",
 ]


### PR DESCRIPTION
To prevent the following issue

```
ERROR ~ Error executing process > 'NFCORE_TAXPROFILER:TAXPROFILER:STANDARDISATION_PROFILES:TAXPASTA_MERGE (metaphlan|metaphlan3)'

Caused by:
  Process `NFCORE_TAXPROFILER:TAXPROFILER:STANDARDISATION_PROFILES:TAXPASTA_MERGE (metaphlan|metaphlan3)` terminated with an error exit status (1)


Command executed:

  taxpasta merge \
      --profiler metaphlan \
      --output metaphlan_metaphlan3.tsv \
       \
       \
       \
      2611_metaphlan3.metaphlan_profile.txt 2613_metaphlan3.metaphlan_profile.txt 2612_metaphlan3.metaphlan_profile.txt
  
  
  cat <<-END_VERSIONS > versions.yml
  "NFCORE_TAXPROFILER:TAXPROFILER:STANDARDISATION_PROFILES:TAXPASTA_MERGE":
      taxpasta: $(taxpasta --version)
  END_VERSIONS

Command exit status:
  1

Command output:
  [13:02:07] CRITICAL Error in sample '2611_metaphlan3.metaphlan_profile' with profile '2611_metaphlan3.metaphlan_profile.txt'.                                                       merge.py:419
             CRITICAL                column                                     failure_case index schema_context                          check  check_number                        merge.py:424
                      0  relative_abundance  KeyError("<class 'pandas.core.series.Series'>")  None         Column  greater_than_or_equal_to(0.0)             0                                    
                      1  relative_abundance  KeyError("<class 'pandas.core.series.Series'>")  None         Column   less_than_or_equal_to(100.0)             1                                    

Command error:
  /home/james/cache/conda/env-b942a33bd54bec81-c9db2a34faaff75b8d8bb7cfbe848899/lib/python3.14/site-packages/pandera/_pandas_deprecated.py:160: FutureWarning: Importing pandas-specific classes and functions from the
  top-level pandera module will be **removed in a future version of pandera**.
  If you're using pandera to validate pandas objects, we highly recommend updating
  your import:
  
  
  # old import
  import pandera as pa
  # new import
  import pandera.pandas as pa
  
  If you're using pandera to validate objects from other compatible libraries
  like pyspark or polars, see the supported libraries section of the documentation
  for more information on how to import pandera:
  
  https://pandera.readthedocs.io/en/stable/supported_libraries.html
  
  To disable this warning, set the environment variable:
  
  
  export DISABLE_PANDERA_IMPORT_WARNING=True
  
    warnings.warn(_future_warning, FutureWarning)
  [13:02:07] CRITICAL Error in sample '2611_metaphlan3.metaphlan_profile' with profile '2611_metaphlan3.metaphlan_profile.txt'.                                                       merge.py:419
             CRITICAL                column                                     failure_case index schema_context                          check  check_number                        merge.py:424
                      0  relative_abundance  KeyError("<class 'pandas.core.series.Series'>")  None         Column  greater_than_or_equal_to(0.0)             0                                    
                      1  relative_abundance  KeyError("<class 'pandas.core.series.Series'>")  None         Column   less_than_or_equal_to(100.0)             1                                    

Work dir:
  /home/james/git/nf-core/taxprofiler/testing/work/6c/b16324f7473f6ccff107ef6234bab4

Tip: you can replicate the issue by changing to the process work dir and entering the command `bash .command.run`

 -- Check '.nextflow.log' file for details
ERROR ~ Pipeline failed. Please refer to troubleshooting docs: https://nf-co.re/docs/usage/troubleshooting

 -- Check '.nextflow.log' file for details
 ```


* [x] fix #160 
* [x] description of feature/fix
* [x] tests added/passed
* [ ] add an entry to the [changelog](../CHANGELOG.md)
